### PR TITLE
modern AMD CPUs apparently benefit from this fix

### DIFF
--- a/features/support/helpers/vm_helper.rb
+++ b/features/support/helpers/vm_helper.rb
@@ -84,6 +84,16 @@ class VM
     rexml.elements['domain/name'].text = @domain_name
     rexml.elements['domain'].add_element('uuid')
     rexml.elements['domain/uuid'].text = LIBVIRT_DOMAIN_UUID
+
+    if ENV.fetch("TAILS_TEST_CPUHACK", "0") == "1" then
+      rexml.elements['domain/cpu'].add_attribute('mode', 'custom')
+      rexml.elements['domain/cpu'].add_attribute('match', 'exact')
+      rexml.elements['domain/cpu'].add_attribute('check', 'partial')
+      rexml.elements['domain/cpu'].add_element('model')
+      rexml.elements['domain/cpu/model'].text = 'core2duo'
+      rexml.elements['domain/cpu/model'].add_attribute('fallback', 'allow')
+    end
+
     update(xml: rexml.to_s)
     set_vcpu($config['VCPUS']) if $config['VCPUS']
     @display = Display.new(@domain_name, x_display)


### PR DESCRIPTION
without it, Tails won't boot.
The choice of "core2duo" is arbitrary and there might be better choices.