### PR TITLE
Don't reset Enigmail settings on Thunderbird restart (refs: #17447)

### DIFF
--- a/config/chroot_local-includes/usr/lib/thunderbird/thunderbird.cfg
+++ b/config/chroot_local-includes/usr/lib/thunderbird/thunderbird.cfg
@@ -82,7 +82,7 @@ lockPref("mail.server.server20.check_new_mail", false);
 
 // We disable Memory Hole for encrypted email until support is more
 // mature and widely spread (#15201).
-pref("extensions.enigmail.protectedHeaders", 0);
+defaultPref("extensions.enigmail.protectedHeaders", 0);
 
 /*
 Enigmail preferences adopted from TorBirdy
@@ -91,16 +91,16 @@ Enigmail preferences adopted from TorBirdy
 // Disable X-Enigmail headers.
 // We don't want to obviously disclose that we're using Enigmail as it may
 // add privacy destroying headers
-pref("extensions.enigmail.addHeaders", false);
+defaultPref("extensions.enigmail.addHeaders", false);
 // Use GnuPG's default comment for signed messages.
-pref("extensions.enigmail.useDefaultComment", true);
+defaultPref("extensions.enigmail.useDefaultComment", true);
 
 // We need to pass some more parameters to GPG.
 //   --no-emit-version: Don't disclose the version
 //   --no-comment: Don't add additional comments (may leak language, etc)
 //   --display-charset utf-8: We want to force UTF-8 everywhere
 //   --keyserver-options no-auto-key-retrieve: Set additional keyserver options
-pref("extensions.enigmail.agentAdditionalParam", "--no-emit-version --no-comments --display-charset utf-8 --keyserver-options no-auto-key-retrieve");
+defaultPref("extensions.enigmail.agentAdditionalParam", "--no-emit-version --no-comments --display-charset utf-8 --keyserver-options no-auto-key-retrieve");
 
 // Force GnuPG to use SHA512.
-pref("extensions.enigmail.mimeHashAlgorithm", 5);
+defaultPref("extensions.enigmail.mimeHashAlgorithm", 5);


### PR DESCRIPTION
Using "pref" in the AutoConfig file resets the value every time
Thunderbird is restarted. If we want the user to be able to change the
value without it being reset, we should use "defaultPref" instead.

FTR, the various functions of AutoConfig are described here:

https://support.mozilla.org/en-US/kb/customizing-firefox-using-autoconfig#w_functions-of-autoconfig