### PR TITLE
Unset the limitation in length of GNOME Shell screencasts

### DIFF
--- a/config/chroot_local-includes/etc/dconf/db/local.d/00_Tails_defaults
+++ b/config/chroot_local-includes/etc/dconf/db/local.d/00_Tails_defaults
@@ -55,6 +55,7 @@ two-finger-scrolling-enabled = true
 [org/gnome/settings-daemon/plugins/media-keys]
 custom-keybindings=['/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom0/']
 screensaver=''
+max-screencast-length=0
 
 [org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom0]
 binding='<Super>l'


### PR DESCRIPTION
By default, the screencasts that can be taken from GNOME Shell
(Ctrl+Alt+Shift+R) are limited to 30s.

Upstream ticket:
https://gitlab.gnome.org/GNOME/gnome-settings-daemon/issues/13